### PR TITLE
Add initial version of manpage

### DIFF
--- a/etc/rmw-en.man
+++ b/etc/rmw-en.man
@@ -1,0 +1,68 @@
+.TH RMW 1 2017-10-14
+.SH NAME
+rmw - remove files, safely
+.SH SYNOPSIS
+\fBrmw\fR \fI[OPTION]\fR... FILE...
+.SH DESCRIPTION
+\fBrmw\fR is a safe-delete utility that sends files to your "Desktop" 
+trash (or a completely separate folder). It can also restore files and permanently
+delete files that were rmw'ed more than a certain (configurable) number of days ago.
+.SH RESTORING FILES
+To restore a file, or multiple files, use the \fB\-z\fR (or \fB\-\-restore\fR) option 
+and specify the path to them in in the \fI<WASTE>/files\fR folder (wildcards ok).
+e.g. '\fBrmw \-z ~/.local/share/Trash/files/foo*\fR'.
+.SH PURGING
+If purging is 'on', \fBrmw\fR will permanently delete files from the folders
+specified in the configuration file after 'x' number of days. 
+Purging can be disabled by using '\fBpurge_after = 0\fR' in configuration file. 
+\fBrmw\fR will only check once per day if it's time to purge (use \fB\-g\fR to check more often).
+Purge requires \fB\-f\fR (\fB\-\-force\fR) to run (in your \fBrmw\fR configuration file, add
+the line '\fBforce_not_required\fR' if you'd rather not use \fB\-\-force\fR when purging).
+.SH OPTIONS
+.TP
+\fB\-B \-\-bypass\fR
+Ignore directory protection settings.
+.TP
+\fB\-c \-\-config\fR \fIfilename\fR
+Use an alternate configuration file.
+.TP
+\fB\-f \-\-force\fR
+Allow rmw to purge files in the background.
+.TP
+\fB\-g \-\-purge\fR
+Purge waste directories (permanently remove files).
+.TP
+\fB\-h \-\-help\fR
+Display a help screen and exit.
+.TP
+\fB\-l \-\-list\fR
+List waste directories.
+.TP
+\fB\-o \-\-orphaned\fR
+Check for orphaned files (for maintenance tasks).
+.TP
+\fB\-s \-\-select\fR
+Displays a list to select files to restore.
+.TP
+\fB\-u \-\-undo-last\fR
+Undo last safe removal.
+.TP
+\fB\-v \-\-verbose\fR
+Print extra information on the output.
+.TP
+\fB\-w \-\-warranty\fR
+Display warranty information and exit.
+.TP
+\fB\-V \-\-version\fR
+Display version and licensing information and exit.
+.TP
+\fB\-z \-\-restore\fR \fIpattern\fR
+Restore files matching \fIpattern\fR.
+.SH DIRECTORIES
+The program's configuration files are stored in \fB~/.config/rmw/\fR.
+By default, the safe-removed files are stored in \fB~/.trash.rmw/\fR.
+.SH LICENCE
+This program is published under the terms of the GNU General Public License,
+version 2 or any later version, as published by the Free Software Foundation.
+.SH AUTHOR
+Written by Andy Alt, with contributions from others.


### PR DESCRIPTION
This changeset adds an initial version of the manpage. The text is mostly copy-pasted from the README file.

If you care about i10n, I can also prepare a Polish version.