### PR TITLE
Issue81 fix

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,5 +1,6 @@
 packextrasdir=@docdir@
 SUBDIRS = src etc
+man1_MANS=./man/rmw.man
 EXTRA_DIST=         \
 BUGS                \
 rmwrc_config.example \

--- a/Makefile.in
+++ b/Makefile.in
@@ -153,7 +153,10 @@ am__uninstall_files_from_dir = { \
     || { echo " ( cd '$$dir' && rm -f" $$files ")"; \
          $(am__cd) "$$dir" && rm -f $$files; }; \
   }
-am__installdirs = "$(DESTDIR)$(packextrasdir)"
+man1dir = $(mandir)/man1
+am__installdirs = "$(DESTDIR)$(man1dir)" "$(DESTDIR)$(packextrasdir)"
+NROFF = nroff
+MANS = $(man1_MANS)
 DATA = $(packextras_DATA)
 RECURSIVE_CLEAN_TARGETS = mostlyclean-recursive clean-recursive	\
   distclean-recursive maintainer-clean-recursive
@@ -323,6 +326,7 @@ top_builddir = @top_builddir@
 top_srcdir = @top_srcdir@
 packextrasdir = @docdir@
 SUBDIRS = src etc
+man1_MANS = ./man/rmw.man
 EXTRA_DIST = \
 BUGS                \
 rmwrc_config.example \
@@ -372,6 +376,47 @@ $(top_srcdir)/configure:  $(am__configure_deps)
 $(ACLOCAL_M4):  $(am__aclocal_m4_deps)
 	$(am__cd) $(srcdir) && $(ACLOCAL) $(ACLOCAL_AMFLAGS)
 $(am__aclocal_m4_deps):
+install-man1: $(man1_MANS)
+	@$(NORMAL_INSTALL)
+	@list1='$(man1_MANS)'; \
+	list2=''; \
+	test -n "$(man1dir)" \
+	  && test -n "`echo $$list1$$list2`" \
+	  || exit 0; \
+	echo " $(MKDIR_P) '$(DESTDIR)$(man1dir)'"; \
+	$(MKDIR_P) "$(DESTDIR)$(man1dir)" || exit 1; \
+	{ for i in $$list1; do echo "$$i"; done;  \
+	if test -n "$$list2"; then \
+	  for i in $$list2; do echo "$$i"; done \
+	    | sed -n '/\.1[a-z]*$$/p'; \
+	fi; \
+	} | while read p; do \
+	  if test -f $$p; then d=; else d="$(srcdir)/"; fi; \
+	  echo "$$d$$p"; echo "$$p"; \
+	done | \
+	sed -e 'n;s,.*/,,;p;h;s,.*\.,,;s,^[^1][0-9a-z]*$$,1,;x' \
+	      -e 's,\.[0-9a-z]*$$,,;$(transform);G;s,\n,.,' | \
+	sed 'N;N;s,\n, ,g' | { \
+	list=; while read file base inst; do \
+	  if test "$$base" = "$$inst"; then list="$$list $$file"; else \
+	    echo " $(INSTALL_DATA) '$$file' '$(DESTDIR)$(man1dir)/$$inst'"; \
+	    $(INSTALL_DATA) "$$file" "$(DESTDIR)$(man1dir)/$$inst" || exit $$?; \
+	  fi; \
+	done; \
+	for i in $$list; do echo "$$i"; done | $(am__base_list) | \
+	while read files; do \
+	  test -z "$$files" || { \
+	    echo " $(INSTALL_DATA) $$files '$(DESTDIR)$(man1dir)'"; \
+	    $(INSTALL_DATA) $$files "$(DESTDIR)$(man1dir)" || exit $$?; }; \
+	done; }
+
+uninstall-man1:
+	@$(NORMAL_UNINSTALL)
+	@list='$(man1_MANS)'; test -n "$(man1dir)" || exit 0; \
+	files=`{ for i in $$list; do echo "$$i"; done; \
+	} | sed -e 's,.*/,,;h;s,.*\.,,;s,^[^1][0-9a-z]*$$,1,;x' \
+	      -e 's,\.[0-9a-z]*$$,,;$(transform);G;s,\n,.,'`; \
+	dir='$(DESTDIR)$(man1dir)'; $(am__uninstall_files_from_dir)
 install-packextrasDATA: $(packextras_DATA)
 	@$(NORMAL_INSTALL)
 	@list='$(packextras_DATA)'; test -n "$(packextrasdir)" || list=; \
@@ -690,10 +735,10 @@ distcleancheck: distclean
 	       exit 1; } >&2
 check-am: all-am
 check: check-recursive
-all-am: Makefile $(DATA)
+all-am: Makefile $(MANS) $(DATA)
 installdirs: installdirs-recursive
 installdirs-am:
-	for dir in "$(DESTDIR)$(packextrasdir)"; do \
+	for dir in "$(DESTDIR)$(man1dir)" "$(DESTDIR)$(packextrasdir)"; do \
 	  test -z "$$dir" || $(MKDIR_P) "$$dir"; \
 	done
 install: install-recursive
@@ -747,7 +792,7 @@ info: info-recursive
 
 info-am:
 
-install-data-am: install-packextrasDATA
+install-data-am: install-man install-packextrasDATA
 
 install-dvi: install-dvi-recursive
 
@@ -763,7 +808,7 @@ install-info: install-info-recursive
 
 install-info-am:
 
-install-man:
+install-man: install-man1
 
 install-pdf: install-pdf-recursive
 
@@ -793,7 +838,9 @@ ps: ps-recursive
 
 ps-am:
 
-uninstall-am: uninstall-packextrasDATA
+uninstall-am: uninstall-man uninstall-packextrasDATA
+
+uninstall-man: uninstall-man1
 
 .MAKE: $(am__recursive_targets) install-am install-strip
 
@@ -806,12 +853,13 @@ uninstall-am: uninstall-packextrasDATA
 	html-am info info-am install install-am install-data \
 	install-data-am install-dvi install-dvi-am install-exec \
 	install-exec-am install-html install-html-am install-info \
-	install-info-am install-man install-packextrasDATA install-pdf \
-	install-pdf-am install-ps install-ps-am install-strip \
-	installcheck installcheck-am installdirs installdirs-am \
-	maintainer-clean maintainer-clean-generic mostlyclean \
-	mostlyclean-generic pdf pdf-am ps ps-am tags tags-am uninstall \
-	uninstall-am uninstall-packextrasDATA
+	install-info-am install-man install-man1 \
+	install-packextrasDATA install-pdf install-pdf-am install-ps \
+	install-ps-am install-strip installcheck installcheck-am \
+	installdirs installdirs-am maintainer-clean \
+	maintainer-clean-generic mostlyclean mostlyclean-generic pdf \
+	pdf-am ps ps-am tags tags-am uninstall uninstall-am \
+	uninstall-man uninstall-man1 uninstall-packextrasDATA
 
 .PRECIOUS: Makefile
 

--- a/man/rmw.man
+++ b/man/rmw.man
@@ -1,0 +1,68 @@
+.TH RMW 1 2017-10-14
+.SH NAME
+rmw - remove files, safely
+.SH SYNOPSIS
+\fBrmw\fR \fI[OPTION]\fR... FILE...
+.SH DESCRIPTION
+\fBrmw\fR is a safe-delete utility that sends files to your "Desktop" 
+trash (or a completely separate folder). It can also restore files and permanently
+delete files that were rmw'ed more than a certain (configurable) number of days ago.
+.SH RESTORING FILES
+To restore a file, or multiple files, use the \fB\-z\fR (or \fB\-\-restore\fR) option 
+and specify the path to them in in the \fI<WASTE>/files\fR folder (wildcards ok).
+e.g. '\fBrmw \-z ~/.local/share/Trash/files/foo*\fR'.
+.SH PURGING
+If purging is 'on', \fBrmw\fR will permanently delete files from the folders
+specified in the configuration file after 'x' number of days. 
+Purging can be disabled by using '\fBpurge_after = 0\fR' in configuration file. 
+\fBrmw\fR will only check once per day if it's time to purge (use \fB\-g\fR to check more often).
+Purge requires \fB\-f\fR (\fB\-\-force\fR) to run (in your \fBrmw\fR configuration file, add
+the line '\fBforce_not_required\fR' if you'd rather not use \fB\-\-force\fR when purging).
+.SH OPTIONS
+.TP
+\fB\-B \-\-bypass\fR
+Ignore directory protection settings.
+.TP
+\fB\-c \-\-config\fR \fIfilename\fR
+Use an alternate configuration file.
+.TP
+\fB\-f \-\-force\fR
+Allow rmw to purge files in the background.
+.TP
+\fB\-g \-\-purge\fR
+Purge waste directories (permanently remove files).
+.TP
+\fB\-h \-\-help\fR
+Display a help screen and exit.
+.TP
+\fB\-l \-\-list\fR
+List waste directories.
+.TP
+\fB\-o \-\-orphaned\fR
+Check for orphaned files (for maintenance tasks).
+.TP
+\fB\-s \-\-select\fR
+Displays a list to select files to restore.
+.TP
+\fB\-u \-\-undo-last\fR
+Undo last safe removal.
+.TP
+\fB\-v \-\-verbose\fR
+Print extra information on the output.
+.TP
+\fB\-w \-\-warranty\fR
+Display warranty information and exit.
+.TP
+\fB\-V \-\-version\fR
+Display version and licensing information and exit.
+.TP
+\fB\-z \-\-restore\fR \fIpattern\fR
+Restore files matching \fIpattern\fR.
+.SH DIRECTORIES
+The program's configuration files are stored in \fB~/.config/rmw/\fR.
+By default, the safe-removed files are stored in \fB~/.trash.rmw/\fR.
+.SH LICENCE
+This program is published under the terms of the GNU General Public License,
+version 2 or any later version, as published by the Free Software Foundation.
+.SH AUTHOR
+Written by Andy Alt, with contributions from others.


### PR DESCRIPTION
This should fix issue #81 . It does not handle different locales, not sure if that is possible with automake alone. There doesn't seem to be any support in automake for installing man pages with different locales.

I copied the english man file into ./man/rmw.man since automake doesn't support renaming the file as it gets copied. If the file name is rmw-en.man, it will be put into the man directory as rmw-en.1 and accessed with `man rmw-en`. 

Not sure if Makefile.in is generated when you run `./configure`, but it was a tracked file so I figured it should be added.