### PR TITLE
Changed all ushort's to unsigned short

### DIFF
--- a/src/functions/config_rmw.c
+++ b/src/functions/config_rmw.c
@@ -160,7 +160,7 @@ Terminating...\n", config_file, CFG_FILE);
 
       erase_char (' ', token_ptr);
 
-      ushort num_value = atoi (token_ptr);
+      unsigned short num_value = atoi (token_ptr);
 
       if (num_value >= 0 && num_value < USHRT_MAX)
         *purge_after = num_value;

--- a/src/main.c
+++ b/src/main.c
@@ -171,7 +171,7 @@ Unable to continue. Exiting...\n");
   char protected_dir[PROTECT_MAX][MP];
 
   /* is reassigned a value in get_config_data() */
-  ushort purge_after = 0;
+  unsigned short purge_after = 0;
 
   short conf_err =
     get_config_data (waste, alt_config, &purge_after, protected_dir, &force);


### PR DESCRIPTION
The tool was not compiling on my mac. It seems the references to `ushort` are unsupported by the default make gcc compiler. 

I renamed those references to `unsigned short` and it compiles now.