### PR TITLE
Add warnings for buffer check fails

### DIFF
--- a/src/functions/strings_rmw.c
+++ b/src/functions/strings_rmw.c
@@ -309,7 +309,7 @@ escape_url (const char *str, char *dest, unsigned short len)
        * character + '\0') */
       if (pos_dest + 2 > len)
       {
-        fprintf(stderr, "rmw: %s(): buffer too small\n", __FUNCTION__);
+        fprintf(stderr, "rmw: %s(): buffer too small (got %hu, needed at least %hu)\n", __FUNCTION__, len, pos_dest+2);
         return 1;
       }
 
@@ -320,7 +320,7 @@ escape_url (const char *str, char *dest, unsigned short len)
       /* Again, check for overflow (3 chars + '\0') */
       if (pos_dest + 4 > len)
       {
-        fprintf(stderr, "rmw: %s(): buffer too small\n", __FUNCTION__);
+        fprintf(stderr, "rmw: %s(): buffer too small (got %hu, needed at least %hu)\n", __FUNCTION__, len, pos_dest+4);
         return 1;
       }
 

--- a/src/functions/strings_rmw.c
+++ b/src/functions/strings_rmw.c
@@ -308,7 +308,10 @@ escape_url (const char *str, char *dest, unsigned short len)
       /* Check for buffer overflow (there should be enough space for 1
        * character + '\0') */
       if (pos_dest + 2 > len)
+      {
+        fprintf(stderr, "rmw: %s(): buffer too small\n", __FUNCTION__);
         return 1;
+      }
 
       dest[pos_dest] = str[pos_str];
       pos_dest += 1;
@@ -316,7 +319,10 @@ escape_url (const char *str, char *dest, unsigned short len)
     else {
       /* Again, check for overflow (3 chars + '\0') */
       if (pos_dest + 4 > len)
+      {
+        fprintf(stderr, "rmw: %s(): buffer too small\n", __FUNCTION__);
         return 1;
+      }
 
       /* A quick explanation to this printf
        * %% - print a '%'

--- a/src/functions/strings_rmw.c
+++ b/src/functions/strings_rmw.c
@@ -364,7 +364,10 @@ unescape_url (const char *str, char *dest, unsigned short len)
       /* Check for buffer overflow (there should be enough space for 1
        * character + '\0') */
       if (pos_dest + 2 > len)
+      {
+        fprintf(stderr, "rmw: %s(): buffer too small (got %hu, needed at least %hu)\n", __FUNCTION__, len, pos_dest+2);
         return 1;
+      }
 
       sscanf(str + pos_str, "%2hhx", dest + pos_dest);
       pos_str += 2;
@@ -373,7 +376,10 @@ unescape_url (const char *str, char *dest, unsigned short len)
       /* Check for buffer overflow (there should be enough space for 1
        * character + '\0') */
       if (pos_dest + 2 > len)
+      {
+        fprintf(stderr, "rmw: %s(): buffer too small (got %hu, needed at least %hu)\n", __FUNCTION__, len, pos_dest+2);
         return 1;
+      }
 
       dest[pos_dest] = str[pos_str];
       pos_str += 1;


### PR DESCRIPTION
This changeset makes a warning be printed if one of the buffer-length checks in `escape_url()` or `unescape_url()` fails. Should fix issue #69.