### PR TITLE
Travis platforms

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,12 @@
+language: c
+os:
+  - linux
+  - osx
+
+compiler:
+  - clang
+  - gcc
+
 script: ./configure --prefix=$PWD/temp-build && make && make install
 
 # safelist

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: c
+
 os:
   - linux
   - osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ script: ./configure --prefix=$PWD/temp-build && make && make install
 branches:
   only:
   - master
+  - travis_platforms
 
 notifications:
   slack: removetowaste:u16fiNsaMeLmg7J4WXifW3Zm


### PR DESCRIPTION
Adds osx platform. Builds with both gcc and clang. Sets language to c to validate the travis file and get a sane env.